### PR TITLE
Demonstrate bug with artifacts

### DIFF
--- a/.github/workflows/nested_callable_workflow.yml
+++ b/.github/workflows/nested_callable_workflow.yml
@@ -12,26 +12,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sleep 1
-        if: ${{ inputs.skip-sleep == false && vars.FORCE_SLEEP == 'true' }}
+        if: ${{ inputs.skip-sleep == false }}
         run: sleep 10
       - name: Sleep 2
-        if: ${{ inputs.skip-sleep == false && vars.FORCE_SLEEP == 'true' }}
+        if: ${{ inputs.skip-sleep == false }}
         run: sleep 10
       - name: Sleep 3
-        if: ${{ inputs.skip-sleep == false && vars.FORCE_SLEEP == 'true' }}
+        if: ${{ inputs.skip-sleep == false }}
         run: sleep 10
       - name: Sleep 4
-        if: ${{ inputs.skip-sleep == false && vars.FORCE_SLEEP == 'true' }}
+        if: ${{ inputs.skip-sleep == false }}
         run: sleep 10
       - name: Sleep 5
-        if: ${{ inputs.skip-sleep == false && vars.FORCE_SLEEP == 'true' }}
+        if: ${{ inputs.skip-sleep == false }}
         run: sleep 10
       - name: Sleep 6
-        if: ${{ inputs.skip-sleep == false && vars.FORCE_SLEEP == 'true' }}
+        if: ${{ inputs.skip-sleep == false }}
         run: sleep 10
-      - name: Maybe fail unit tests
-        if: ${{ inputs.skip-sleep == true && vars.SKIP_FAILURE == 'false' }}
-        run: exit 1
+      - name: Get artifact if already exists
+        # This will fail the first time this workflow is run
+        id: download
+        if: ${{ inputs.skip-sleep == true }}
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact
+      - name: Create artifact if not there
+        if: always() && (inputs.skip-sleep == true)
+        run: touch artifact.md
+      - name: Upload artifact if not there
+        if: always() && (inputs.skip-sleep == true)
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact
+          path: artifact.md
       - name: Dummy
         run: echo "Dummy"
 


### PR DESCRIPTION
This implementation uses artifact upload and download to emulate a workflow that can fail without any code changes.

Here is the initial run of this change with the single failure and 3 cancelations: https://github.com/thebrowsercompany/nested-callable-workflow-dependency/actions/runs/7718021070
Here is the run where the single failing workflow in the matrix was rerun but then the entire check was incorrectly marked as success: https://github.com/thebrowsercompany/nested-callable-workflow-dependency/actions/runs/7718021070. 
Watch this video of the issue:

https://github.com/thebrowsercompany/nested-callable-workflow-dependency/assets/1282845/bc9e9d28-9345-41a3-b227-79a89e1c7899



The way to exercise the bug:
- Re-run all jobs in the checks for this PR
- Observe that the first of the matrix jobs fails which causes the others to cancel
- Click the rerun button on the single job marked as failed
- Observe that only that job runs and it succeeds and now the entire check is marked as success even though the canceled jobs are still marked as failed and did not rerun
